### PR TITLE
Add ErrorCallback

### DIFF
--- a/src/asyncComponent.js
+++ b/src/asyncComponent.js
@@ -11,6 +11,7 @@ function asyncComponent(config) {
     serverMode = 'resolve',
     LoadingComponent,
     ErrorComponent,
+    errorCallback,
   } = config
 
   if (validSSRModes.indexOf(serverMode) === -1) {
@@ -157,12 +158,17 @@ function asyncComponent(config) {
             return undefined
           }
           if (env === 'node' || (env === 'browser' && !ErrorComponent)) {
-            // We will at least log the error so that user isn't completely
-            // unaware of an error occurring.
-            // eslint-disable-next-line no-console
-            console.warn('Failed to resolve asyncComponent')
-            // eslint-disable-next-line no-console
-            console.warn(error)
+            if (errorCallback) {
+              // Allow user to decide how to log error
+              errorCallback(error); 
+            } else {
+              // We will at least log the error so that user isn't completely
+              // unaware of an error occurring.
+              // eslint-disable-next-line no-console
+              console.warn('Failed to resolve asyncComponent')
+              // eslint-disable-next-line no-console
+              console.warn(error)
+            }
           }
           sharedState.error = error
           this.registerErrorState(error)


### PR DESCRIPTION
Fixes #29 

I want to be able to log errors in sentry.io if the component ever throw an error. Because asyncComponents will catch errors in the render method the errors I might get in sentry are only the exceptions from React so I won't ever get the underlying cause. 

I tried to use the ErrorComponent to handle the error but I realize that if there is an error is in the render method React doesn't seem to mount the ErrorComponent. Most likely my components  won't throw an error in production but I would still want to be able to log the errors in the case that it does. 