### PR TITLE
rename `asyncBootstrap` to `bootstrap`

### DIFF
--- a/src/asyncComponent.js
+++ b/src/asyncComponent.js
@@ -74,7 +74,7 @@ function asyncComponent(config) {
     }
 
     // @see react-async-bootstrapper
-    asyncBootstrap() {
+    bootstrap() {
       const { asyncComponents, asyncComponentsAncestor } = this.context
       const { shouldRehydrate } = asyncComponents
 


### PR DESCRIPTION
`asyncBootstrap` has been deprecated in favor of `bootstrap`

```
Deprecation notice: you are using the deprecated "asyncBootsrap" for "react-async-bootstrapper", please rename these to "bootstrap"
```