### PR TITLE
use constructor instead of componentWillMount

### DIFF
--- a/src/asyncComponent.js
+++ b/src/asyncComponent.js
@@ -89,6 +89,17 @@ export default function asyncComponent(config) {
       }),
     }
 
+    constructor(props, context) {
+      super(props, context)
+      if (context.asyncComponents != null) {
+        state.asyncComponents = context.asyncComponents
+        state.asyncComponentsAncestor = context.asyncComponentsAncestor
+        if (!state.id) {
+          state.id = this.context.asyncComponents.getNextId()
+        }
+      }
+    }
+
     getChildContext() {
       return {
         asyncComponentsAncestor:
@@ -97,16 +108,6 @@ export default function asyncComponent(config) {
             : {
                 isBoundary: serverMode === 'boundary',
               },
-      }
-    }
-
-    componentWillMount() {
-      if (this.context.asyncComponents != null) {
-        state.asyncComponents = this.context.asyncComponents
-        state.asyncComponentsAncestor = this.context.asyncComponentsAncestor
-        if (!state.id) {
-          state.id = this.context.asyncComponents.getNextId()
-        }
       }
     }
 


### PR DESCRIPTION
This moves setup into the constructor, to avoid error when using `<React.Strict>` wrapper to check for futureproofing.
React 17 won't allow componentWillMount.

Also removed console.log calls, since libs shouldn't be so chatty in production IMHO.