### PR TITLE
Remove checking "resolving" in needToResolveOnBrowser

### DIFF
--- a/src/__tests__/integration.test.js
+++ b/src/__tests__/integration.test.js
@@ -193,6 +193,28 @@ describe('integration tests', () => {
       const wrapper = mount(app)
       expect(wrapper.html()).toContain('Loading...')
     })
+
+    it('renders the LoadingComponent without bootstrapper', async () => {
+      const AsyncComponent = asyncComponent({
+        resolve: () =>
+          new Promise(resolve =>
+            setTimeout(() => resolve(() => <div>foo</div>), 100),
+          ),
+        LoadingComponent,
+      })
+      const Comp = ({ compKey }) => (
+        <div>{compKey ? <AsyncComponent key={compKey} /> : null}</div>
+      )
+      const wrapper = mount(<Comp compKey="1" />)
+      expect(wrapper.html()).toContain('Loading...')
+      // Unmount the component immediately
+      wrapper.setProps({
+        compKey: '2',
+      })
+      expect(wrapper.html()).toContain('Loading...')
+      await new Promise(resolve => setTimeout(resolve, 100))
+      expect(wrapper.html()).not.toContain('Loading...')
+    })
   })
 
   describe('server rendering', () => {

--- a/src/__tests__/integration.test.js
+++ b/src/__tests__/integration.test.js
@@ -212,7 +212,7 @@ describe('integration tests', () => {
         compKey: '2',
       })
       expect(wrapper.html()).toContain('Loading...')
-      await new Promise(resolve => setTimeout(resolve, 100))
+      await new Promise(resolve => setTimeout(resolve, 150))
       expect(wrapper.html()).not.toContain('Loading...')
     })
   })

--- a/src/asyncComponent.js
+++ b/src/asyncComponent.js
@@ -44,7 +44,6 @@ export default function asyncComponent(config) {
   const needToResolveOnBrowser = () =>
     state.module == null &&
     state.error == null &&
-    !state.resolving &&
     typeof window !== 'undefined'
 
   // Takes the given module and if it has a ".default" the ".default" will


### PR DESCRIPTION
The resolving condition will cause a bug when the component is resolving, then the current component is unmounted and then the component is recreated again right before the module is resolved. 
In this case, the component should get the existing resolver and update the rendering after the module is resolved. However, the resolving checking blocks this update.